### PR TITLE
Add additional type for systemd(timers, paths, etc)

### DIFF
--- a/nixproc/backends/systemd/create-systemd-service.nix
+++ b/nixproc/backends/systemd/create-systemd-service.nix
@@ -70,11 +70,7 @@ let
         value = builtins.getAttr name properties;
       in
       if forceDisableUserChange && (name == "User" || name == "Group") then "" else # Don't change user privileges when we force it to be disabled
-      ''${if builtins.isList value then
-        lib.strings.concatMapStringsSep "\n" (x: "${name}=${toString x}") value
-      else
-        "${name}=${toString value}"
-      end}
+      ''${if builtins.isList value then lib.strings.concatMapStringsSep "\n" (x: "${name}=${toString x}") value else "${name}=${toString value}"}
       ''
     ) (builtins.attrNames properties)}''
   + (if title == "Service" then generateEnvironmentVariables _environment else "")

--- a/nixproc/backends/systemd/create-systemd-service.nix
+++ b/nixproc/backends/systemd/create-systemd-service.nix
@@ -70,7 +70,11 @@ let
         value = builtins.getAttr name properties;
       in
       if forceDisableUserChange && (name == "User" || name == "Group") then "" else # Don't change user privileges when we force it to be disabled
-      ''${name}=${toString value}
+      ''${if builtins.isList value then
+        lib.strings.concatMapStringsSep "\n" (x: "${name}=${toString x}") value
+      else
+        "${name}=${toString value}"
+      end}
       ''
     ) (builtins.attrNames properties)}''
   + (if title == "Service" then generateEnvironmentVariables _environment else "")

--- a/nixproc/backends/systemd/create-systemd-service.nix
+++ b/nixproc/backends/systemd/create-systemd-service.nix
@@ -15,6 +15,7 @@
 name
 # An attribute set specifying arbitrary environment variables
 , environment ? {}
+, unitType ? "service"
 # List of supervisord services that this configuration depends on.
 # These properties are translated to Wants= and After= properties to ensure
 # proper activation ordering and that the dependencies are started first
@@ -36,7 +37,7 @@ let
     inherit lib;
   };
 
-  sections = removeAttrs args [ "name" "environment" "dependencies" "path" "credentials" "postInstall" ];
+  sections = removeAttrs args [ "unitType" "name" "environment" "dependencies" "path" "credentials" "postInstall" ];
 
   _environment = util.appendPathToEnvironment {
     inherit environment;
@@ -56,8 +57,8 @@ let
     if dependencies == [] then ""
     else
     ''
-      Wants=${toString (map (dependency: "${dependency.name}.service") dependencies)}
-      After=${toString (map (dependency: "${dependency.name}.service") dependencies)}
+      Wants=${toString (map (dependency: "${dependency.name}.${dependency.unitType}") dependencies)}
+      After=${toString (map (dependency: "${dependency.name}.${dependency.unitType}") dependencies)}
     '';
 
   generateSection = {title, properties}:
@@ -85,11 +86,11 @@ let
       }
    ) (builtins.attrNames sections);
 
-  service = writeTextFile {
-    name = "${name}.service";
+  systemdFile = writeTextFile {
+    name = "${name}.${unitType}";
     text = ''
       ${generateSections sections}
-      ${lib.optionalString (!(sections ? Service) && _environment != {}) ''
+      ${lib.optionalString (!(sections ? Service) && _environment != {} && unitType == "service") ''
         [Service]
 
         ${generateEnvironmentVariables _environment}''}
@@ -106,15 +107,17 @@ in
 stdenv.mkDerivation {
   name = "${prefix}${name}";
 
+  inherit unitType;
+
   buildCommand = ''
     mkdir -p $out/etc/systemd/system
-    ln -s ${service} $out/etc/systemd/system/${prefix}${name}.service
+    ln -s ${systemdFile} $out/etc/systemd/system/${prefix}${name}.${unitType}
 
     ${lib.optionalString (dependencies != []) ''
-      mkdir -p $out/etc/systemd/system/${prefix}${name}.service.wants
+      mkdir -p $out/etc/systemd/system/${prefix}${name}.${unitType}.wants
 
       ${lib.concatMapStrings (dependency: ''
-        ln -s ${dependency}/etc/systemd/system/${dependency.name}.service $out/etc/systemd/system/${prefix}${name}.service.wants
+        ln -s ${dependency}/etc/systemd/system/${dependency.name}.${dependency.unitType} $out/etc/systemd/system/${prefix}${name}.${unitType}.wants
       '') dependencies}
     ''}
 

--- a/tools/systemd/nixproc-systemd-deploy.in
+++ b/tools/systemd/nixproc-systemd-deploy.in
@@ -143,7 +143,7 @@ oldunits=()
 
 if [ -d "$oldProfilePath" ]
 then
-    for i in $oldProfilePath/etc/systemd/system/*.service
+    for i in $oldProfilePath/etc/systemd/system/*
     do
         currentPath=$(readlink -f "$i")
         oldunits+=($currentPath)
@@ -154,7 +154,7 @@ fi
 
 newunits=()
 
-for i in $profilePath/etc/systemd/system/*.service
+for i in $profilePath/etc/systemd/system/*
 do
     currentPath=$(readlink -f "$i")
     newunits+=($currentPath)
@@ -168,7 +168,7 @@ if [ "$oldProfilePath" != "" ]
 then
     # Stop obsolete units
 
-    for i in $oldProfilePath/etc/systemd/system/*.service
+    for i in $oldProfilePath/etc/systemd/system/*
     do
         if ! containsElement "$(readlink -f "$i")" "${newunits[@]}"
         then
@@ -178,7 +178,7 @@ then
 
     # Remove obsolete units
 
-    for i in $oldProfilePath/etc/systemd/system/*.service
+    for i in $oldProfilePath/etc/systemd/system/*
     do
         if ! containsElement "$(readlink -f "$i")" "${newunits[@]}"
         then
@@ -195,7 +195,7 @@ fi
 
 # Add new units
 
-for i in $profilePath/etc/systemd/system/*.service
+for i in $profilePath/etc/systemd/system/*
 do
     if ! containsElement "$(readlink -f "$i")" "${oldunits[@]}"
     then
@@ -212,7 +212,7 @@ done
 systemctl $systemdUserArg daemon-reload
 
 # Start all units in the new configuration
-for i in $profilePath/etc/systemd/system/*.service
+for i in $profilePath/etc/systemd/system/*
 do
     systemctl $systemdUserArg start "$(basename "$i")"
 done

--- a/tools/systemd/nixproc-systemd-deploy.in
+++ b/tools/systemd/nixproc-systemd-deploy.in
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-set -x
 shopt -s nullglob
 
 showUsage()

--- a/tools/systemd/nixproc-systemd-deploy.in
+++ b/tools/systemd/nixproc-systemd-deploy.in
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -x
 shopt -s nullglob
 
 showUsage()

--- a/tools/systemd/nixproc-systemd-deploy.in
+++ b/tools/systemd/nixproc-systemd-deploy.in
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 shopt -s nullglob
-
 showUsage()
 {
     cat <<EOF
@@ -229,7 +228,7 @@ do
     if [[ "$i" =~ .wants ]]; then
       continue
     fi
-    systemctl $systemdUserArg stop "$(basename "$i")"
+    systemctl $systemdUserArg stop "$(basename "$i")" || true
 done
 
 # Reload the systemd configuration

--- a/tools/systemd/nixproc-systemd-deploy.in
+++ b/tools/systemd/nixproc-systemd-deploy.in
@@ -224,6 +224,15 @@ do
     fi
 done
 
+# Stop all units
+for i in $profilePath/etc/systemd/system/*
+do
+    if [[ "$i" =~ .wants ]]; then
+      continue
+    fi
+    systemctl $systemdUserArg stop "$(basename "$i")"
+done
+
 # Reload the systemd configuration
 systemctl $systemdUserArg daemon-reload
 

--- a/tools/systemd/nixproc-systemd-deploy.in
+++ b/tools/systemd/nixproc-systemd-deploy.in
@@ -240,7 +240,6 @@ do
     if [[ "$i" =~ .wants ]]; then
       continue
     fi
-    systemctl $systemdUserArg daemon-reload
     systemctl $systemdUserArg start "$(basename "$i")"
 done
 

--- a/tools/systemd/nixproc-systemd-deploy.in
+++ b/tools/systemd/nixproc-systemd-deploy.in
@@ -143,8 +143,11 @@ oldunits=()
 
 if [ -d "$oldProfilePath" ]
 then
-    for i in $oldProfilePath/etc/systemd/system/*.service
+    for i in $oldProfilePath/etc/systemd/system/*
     do
+        if [[ "$i" =~ .wants ]]; then
+          continue
+        fi
         currentPath=$(readlink -f "$i")
         oldunits+=($currentPath)
     done
@@ -154,8 +157,11 @@ fi
 
 newunits=()
 
-for i in $profilePath/etc/systemd/system/*.service
+for i in $profilePath/etc/systemd/system/*
 do
+    if [[ "$i" =~ .wants ]]; then
+      continue
+    fi
     currentPath=$(readlink -f "$i")
     newunits+=($currentPath)
 done
@@ -168,8 +174,11 @@ if [ "$oldProfilePath" != "" ]
 then
     # Stop obsolete units
 
-    for i in $oldProfilePath/etc/systemd/system/*.service
+    for i in $oldProfilePath/etc/systemd/system/*
     do
+        if [[ "$i" =~ .wants ]]; then
+          continue
+        fi
         if ! containsElement "$(readlink -f "$i")" "${newunits[@]}"
         then
             systemctl $systemdUserArg stop "$(basename "$i")"
@@ -178,8 +187,11 @@ then
 
     # Remove obsolete units
 
-    for i in $oldProfilePath/etc/systemd/system/*.service
+    for i in $oldProfilePath/etc/systemd/system/*
     do
+        if [[ "$i" =~ .wants ]]; then
+          continue
+        fi
         if ! containsElement "$(readlink -f "$i")" "${newunits[@]}"
         then
             unitTargetPath="$SYSTEMD_TARGET_DIR/$(basename "$i")"
@@ -195,8 +207,11 @@ fi
 
 # Add new units
 
-for i in $profilePath/etc/systemd/system/*.service
+for i in $profilePath/etc/systemd/system/*
 do
+    if [[ "$i" =~ .wants ]]; then
+      continue
+    fi
     if ! containsElement "$(readlink -f "$i")" "${oldunits[@]}"
     then
         if [ -d "$i.wants" ]
@@ -212,8 +227,11 @@ done
 systemctl $systemdUserArg daemon-reload
 
 # Start all units in the new configuration
-for i in $profilePath/etc/systemd/system/*.service
+for i in $profilePath/etc/systemd/system/*
 do
+    if [[ "$i" =~ .wants ]]; then
+      continue
+    fi
     systemctl $systemdUserArg start "$(basename "$i")"
 done
 

--- a/tools/systemd/nixproc-systemd-deploy.in
+++ b/tools/systemd/nixproc-systemd-deploy.in
@@ -143,7 +143,7 @@ oldunits=()
 
 if [ -d "$oldProfilePath" ]
 then
-    for i in $oldProfilePath/etc/systemd/system/*
+    for i in $oldProfilePath/etc/systemd/system/*.service
     do
         currentPath=$(readlink -f "$i")
         oldunits+=($currentPath)
@@ -154,7 +154,7 @@ fi
 
 newunits=()
 
-for i in $profilePath/etc/systemd/system/*
+for i in $profilePath/etc/systemd/system/*.service
 do
     currentPath=$(readlink -f "$i")
     newunits+=($currentPath)
@@ -168,7 +168,7 @@ if [ "$oldProfilePath" != "" ]
 then
     # Stop obsolete units
 
-    for i in $oldProfilePath/etc/systemd/system/*
+    for i in $oldProfilePath/etc/systemd/system/*.service
     do
         if ! containsElement "$(readlink -f "$i")" "${newunits[@]}"
         then
@@ -178,7 +178,7 @@ then
 
     # Remove obsolete units
 
-    for i in $oldProfilePath/etc/systemd/system/*
+    for i in $oldProfilePath/etc/systemd/system/*.service
     do
         if ! containsElement "$(readlink -f "$i")" "${newunits[@]}"
         then
@@ -195,7 +195,7 @@ fi
 
 # Add new units
 
-for i in $profilePath/etc/systemd/system/*
+for i in $profilePath/etc/systemd/system/*.service
 do
     if ! containsElement "$(readlink -f "$i")" "${oldunits[@]}"
     then
@@ -212,7 +212,7 @@ done
 systemctl $systemdUserArg daemon-reload
 
 # Start all units in the new configuration
-for i in $profilePath/etc/systemd/system/*
+for i in $profilePath/etc/systemd/system/*.service
 do
     systemctl $systemdUserArg start "$(basename "$i")"
 done

--- a/tools/systemd/nixproc-systemd-deploy.in
+++ b/tools/systemd/nixproc-systemd-deploy.in
@@ -240,6 +240,7 @@ do
     if [[ "$i" =~ .wants ]]; then
       continue
     fi
+    systemctl $systemdUserArg daemon-reload
     systemctl $systemdUserArg start "$(basename "$i")"
 done
 


### PR DESCRIPTION
This PR introduce an additional param call `unitType`(which default to `service`) to allow adding additional systemd types like timers, paths,socket,etc